### PR TITLE
#19 Fix compilation errors after merging main

### DIFF
--- a/src/main/java/at/jku/se/smarthome/service/api/ServiceRegistry.java
+++ b/src/main/java/at/jku/se/smarthome/service/api/ServiceRegistry.java
@@ -1,4 +1,5 @@
 package at.jku.se.smarthome.service.api;
+import at.jku.se.smarthome.service.real.log.JdbcLogService;
 import at.jku.se.smarthome.service.real.room.JdbcRoomService;
 import at.jku.se.smarthome.service.real.schedule.JdbcScheduleService;
 

--- a/src/main/java/at/jku/se/smarthome/service/mock/MockLogService.java
+++ b/src/main/java/at/jku/se/smarthome/service/mock/MockLogService.java
@@ -5,6 +5,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.stream.Collectors;
 
 import at.jku.se.smarthome.model.LogEntry;
+import at.jku.se.smarthome.service.api.LogService;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
@@ -12,7 +13,7 @@ import javafx.collections.ObservableList;
  * Mock Log Service providing activity logging functionality.
  * Records all manual and automated state changes with detailed information.
  */
-public class MockLogService {
+public class MockLogService implements LogService {
     
     private static MockLogService instance;
     private final ObservableList<LogEntry> logs;


### PR DESCRIPTION
## Summary
- Add missing import for `JdbcLogService` in `ServiceRegistry`
- Add `implements LogService` to `MockLogService` (methods already present, declaration was missing)

Both issues originated from main before the merge.

## Test plan
- [x] `mvn compile` passes cleanly
- [x] `TestMockRuleService` and `TestMockLogService` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)