### PR TITLE
fix: resolve UserService singleton mismatch in controllers

### DIFF
--- a/src/main/java/at/jku/se/smarthome/controller/RoomsController.java
+++ b/src/main/java/at/jku/se/smarthome/controller/RoomsController.java
@@ -4,7 +4,7 @@ import at.jku.se.smarthome.model.Device;
 import at.jku.se.smarthome.model.Room;
 import at.jku.se.smarthome.service.api.RoomService;
 import at.jku.se.smarthome.service.api.ServiceRegistry;
-import at.jku.se.smarthome.service.mock.MockUserService;
+import at.jku.se.smarthome.service.api.UserService;
 import javafx.fxml.FXML;
 import javafx.geometry.Pos;
 import javafx.scene.control.Alert;
@@ -50,7 +50,7 @@ public class RoomsController {
     private Label selectedRoomLabel;
     
     private final RoomService roomService = ServiceRegistry.getRoomService();
-    private final MockUserService userService = MockUserService.getInstance();
+    private final UserService userService = ServiceRegistry.getUserService();
     private Room selectedRoom;
     
     @FXML

--- a/src/main/java/at/jku/se/smarthome/controller/RulesController.java
+++ b/src/main/java/at/jku/se/smarthome/controller/RulesController.java
@@ -8,7 +8,7 @@ import at.jku.se.smarthome.model.Rule;
 import at.jku.se.smarthome.service.api.RoomService;
 import at.jku.se.smarthome.service.api.ServiceRegistry;
 import at.jku.se.smarthome.service.mock.MockRuleService;
-import at.jku.se.smarthome.service.mock.MockUserService;
+import at.jku.se.smarthome.service.api.UserService;
 import javafx.fxml.FXML;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -60,7 +60,7 @@ public class RulesController {
     
     private final MockRuleService ruleService = MockRuleService.getInstance();
     private final RoomService roomService = ServiceRegistry.getRoomService();
-    private final MockUserService userService = MockUserService.getInstance();
+    private final UserService userService = ServiceRegistry.getUserService();
     
     @FXML
     private void initialize() {

--- a/src/main/java/at/jku/se/smarthome/controller/ScenesController.java
+++ b/src/main/java/at/jku/se/smarthome/controller/ScenesController.java
@@ -13,7 +13,7 @@ import at.jku.se.smarthome.model.Scene;
 import at.jku.se.smarthome.service.api.RoomService;
 import at.jku.se.smarthome.service.api.ServiceRegistry;
 import at.jku.se.smarthome.service.mock.MockSceneService;
-import at.jku.se.smarthome.service.mock.MockUserService;
+import at.jku.se.smarthome.service.api.UserService;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
@@ -46,7 +46,7 @@ public class ScenesController {
     
     private final MockSceneService sceneService = MockSceneService.getInstance();
     private final RoomService roomService = ServiceRegistry.getRoomService();
-    private final MockUserService userService = MockUserService.getInstance();
+    private final UserService userService = ServiceRegistry.getUserService();
     private boolean refreshingDeviceOptions;
     
     @FXML

--- a/src/main/java/at/jku/se/smarthome/controller/SettingsController.java
+++ b/src/main/java/at/jku/se/smarthome/controller/SettingsController.java
@@ -1,6 +1,7 @@
 package at.jku.se.smarthome.controller;
 
-import at.jku.se.smarthome.service.mock.MockUserService;
+import at.jku.se.smarthome.service.api.ServiceRegistry;
+import at.jku.se.smarthome.service.api.UserService;
 import javafx.fxml.FXML;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Label;
@@ -20,7 +21,7 @@ public class SettingsController {
     @FXML
     private PasswordField confirmPasswordField;
     
-    private final MockUserService userService = MockUserService.getInstance();
+    private final UserService userService = ServiceRegistry.getUserService();
     
     @FXML
     private void initialize() {

--- a/src/main/java/at/jku/se/smarthome/controller/VacationModeController.java
+++ b/src/main/java/at/jku/se/smarthome/controller/VacationModeController.java
@@ -8,7 +8,7 @@ import at.jku.se.smarthome.model.VacationModeConfig;
 import at.jku.se.smarthome.service.api.ScheduleService;
 import at.jku.se.smarthome.service.api.ServiceRegistry;
 import at.jku.se.smarthome.service.api.RoomService;
-import at.jku.se.smarthome.service.mock.MockUserService;
+import at.jku.se.smarthome.service.api.UserService;
 import at.jku.se.smarthome.service.mock.MockVacationModeService;
 import javafx.fxml.FXML;
 import javafx.scene.control.Alert;
@@ -58,7 +58,7 @@ public class VacationModeController {
     private final ScheduleService scheduleService = ServiceRegistry.getScheduleService();
     private final MockVacationModeService vacationModeService = MockVacationModeService.getInstance();
     private final RoomService roomService = ServiceRegistry.getRoomService();
-    private final MockUserService userService = MockUserService.getInstance();
+    private final UserService userService = ServiceRegistry.getUserService();
     
     @FXML
     private void initialize() {


### PR DESCRIPTION
## Summary
- Controllers were using `MockUserService.getInstance()` directly while login uses `ServiceRegistry.getUserService()` (`JdbcUserService`) — two separate instances with no shared session
- This caused `canManageSystem()` to always return `false` for logged-in owners, disabling Add Room, Add Rule, Scenes, Settings, and Vacation Mode
- Fixed by replacing `MockUserService.getInstance()` with `ServiceRegistry.getUserService()` in all five affected controllers

## Affected files
- `RoomsController` — Add Room / Add Device buttons stayed disabled
- `RulesController` — Edit/Delete rule buttons stayed disabled
- `ScenesController` — Scene management stayed disabled
- `SettingsController` — could not read current user email
- `VacationModeController` — permission checks always failed

## Test plan
- [x] Run `mvn javafx:run`
- [x] Log in as `owner@smarthome.com` / `password123`
- [x] Navigate to Rooms → "+ Add Room" button is enabled and works
- [x] Navigate to Automation → Edit/Delete buttons on rules are enabled
- [x] Log in as `member@smarthome.com` / `password123` → all management buttons remain disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)