### PR TITLE
#20 [2h] Implement FR-20 user management: invite, revoke, restore with …

### DIFF
--- a/src/main/java/at/jku/se/smarthome/service/mock/MockUserService.java
+++ b/src/main/java/at/jku/se/smarthome/service/mock/MockUserService.java
@@ -361,6 +361,7 @@ public class MockUserService extends UserService {
         * @return true when the invite was created, otherwise false
      */
     @Override
+    @SuppressWarnings("PMD.OnlyOneReturn")
     public boolean inviteUser(String email, String role) {
         if (email == null || email.isBlank() || !email.contains("@")) {
             return false;
@@ -424,6 +425,7 @@ public class MockUserService extends UserService {
         return restored;
     }
 
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private void tryLog(String target, String action, String actor) {
         try {
             LogService log = ServiceRegistry.getLogService();
@@ -435,7 +437,7 @@ public class MockUserService extends UserService {
                     System.Logger.Level.WARNING, "Failed to log user management action.", exception);
         }
     }
-    
+
     /**
         * Logs out the current user.
      */

--- a/src/main/java/at/jku/se/smarthome/service/mock/MockUserService.java
+++ b/src/main/java/at/jku/se/smarthome/service/mock/MockUserService.java
@@ -425,14 +425,14 @@ public class MockUserService extends UserService {
         return restored;
     }
 
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
     private void tryLog(String target, String action, String actor) {
         try {
             LogService log = ServiceRegistry.getLogService();
             if (log != null) {
                 log.addLogEntry(target, action, actor);
             }
-        } catch (Exception exception) {
+        } catch (Throwable exception) {
             System.getLogger(MockUserService.class.getName()).log(
                     System.Logger.Level.WARNING, "Failed to log user management action.", exception);
         }

--- a/src/main/java/at/jku/se/smarthome/service/mock/MockUserService.java
+++ b/src/main/java/at/jku/se/smarthome/service/mock/MockUserService.java
@@ -5,6 +5,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+import at.jku.se.smarthome.service.api.LogService;
+import at.jku.se.smarthome.service.api.ServiceRegistry;
+
 import org.mindrot.jbcrypt.BCrypt;
 
 import at.jku.se.smarthome.model.User;
@@ -359,15 +362,21 @@ public class MockUserService extends UserService {
      */
     @Override
     public boolean inviteUser(String email, String role) {
+        if (email == null || email.isBlank() || !email.contains("@")) {
+            return false;
+        }
+        String normalizedEmail = email.trim().toLowerCase(Locale.ROOT);
         boolean invited = false;
-        if (!users.stream().anyMatch(u -> u.getEmail().equals(email))) {
-            User newUser = new User(email, email.split("@")[0], "temporary", role, "Pending");
+        if (users.stream().noneMatch(u -> u.getEmail().equals(normalizedEmail))) {
+            String username = normalizedEmail.split("@")[0];
+            User newUser = new User(normalizedEmail, username, "temporary", role, "Pending");
             users.add(newUser);
+            tryLog(normalizedEmail, "Invited", "Owner");
             invited = true;
         }
         return invited;
     }
-    
+
     /**
         * Revokes access for a user.
         *
@@ -387,6 +396,7 @@ public class MockUserService extends UserService {
             if (email.equals(currentUserEmail)) {
                 logout();
             }
+            tryLog(email, "Access revoked", "Owner");
             revoked = true;
         }
         return revoked;
@@ -408,9 +418,22 @@ public class MockUserService extends UserService {
 
         if (user != null && !"Owner".equalsIgnoreCase(user.getRole())) {
             user.setStatus("Active");
+            tryLog(email, "Access restored", "Owner");
             restored = true;
         }
         return restored;
+    }
+
+    private void tryLog(String target, String action, String actor) {
+        try {
+            LogService log = ServiceRegistry.getLogService();
+            if (log != null) {
+                log.addLogEntry(target, action, actor);
+            }
+        } catch (Exception exception) {
+            System.getLogger(MockUserService.class.getName()).log(
+                    System.Logger.Level.WARNING, "Failed to log user management action.", exception);
+        }
     }
     
     /**

--- a/src/main/java/at/jku/se/smarthome/service/real/auth/JdbcUserRegistrationStore.java
+++ b/src/main/java/at/jku/se/smarthome/service/real/auth/JdbcUserRegistrationStore.java
@@ -133,6 +133,21 @@ public class JdbcUserRegistrationStore implements UserRegistrationStore {
         }
     }
 
+    @Override
+    public void updateStatus(String normalizedEmail, String newStatus) throws StoreException {
+        try (Connection connection = openConnection()) {
+            ensureSchema(connection);
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "UPDATE users SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE email = ?")) {
+                statement.setString(1, newStatus);
+                statement.setString(2, normalizedEmail);
+                statement.executeUpdate();
+            }
+        } catch (SQLException exception) {
+            throw new StoreException("Failed to update user status.", exception);
+        }
+    }
+
     private Connection openConnection() throws StoreException, SQLException {
         DatabaseSettings settings = loadSettings();
         return DriverManager.getConnection(settings.jdbcUrl(), settings.username(), settings.password());

--- a/src/main/java/at/jku/se/smarthome/service/real/auth/JdbcUserService.java
+++ b/src/main/java/at/jku/se/smarthome/service/real/auth/JdbcUserService.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import org.mindrot.jbcrypt.BCrypt;
 
 import at.jku.se.smarthome.model.User;
+import at.jku.se.smarthome.service.api.LogService;
+import at.jku.se.smarthome.service.api.ServiceRegistry;
 import at.jku.se.smarthome.service.api.UserService;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -247,13 +249,28 @@ public final class JdbcUserService extends UserService {
 
     @Override
     public boolean inviteUser(String email, String role) {
-        boolean invited = false;
-        if (!users.stream().anyMatch(u -> u.getEmail().equals(email))) {
-            User newUser = new User(email, email.contains("@") ? email.split("@")[0] : email, "temporary", role, "Pending");
-            users.add(newUser);
-            invited = true;
+        if (email == null || email.isBlank() || !email.contains("@")) {
+            return false;
         }
-        return invited;
+        String normalizedEmail = normalizeEmail(email);
+        if (normalizedEmail == null) {
+            return false;
+        }
+        if (users.stream().anyMatch(u -> u.getEmail().equals(normalizedEmail))) {
+            return false;
+        }
+        try {
+            String username = normalizedEmail.split("@")[0];
+            registrationStore.save(new UserRegistrationStore.PersistedUser(
+                    normalizedEmail, username, "*INVITED*", role, "Pending"));
+            users.add(new User(normalizedEmail, username, "*INVITED*", role, "Pending"));
+            tryLog(normalizedEmail, "Invited", "Owner");
+            return true;
+        } catch (UserRegistrationStore.StoreException exception) {
+            System.getLogger(JdbcUserService.class.getName()).log(
+                    System.Logger.Level.WARNING, "Failed to persist invited user.", exception);
+            return false;
+        }
     }
 
     @Override
@@ -270,6 +287,13 @@ public final class JdbcUserService extends UserService {
                 logout();
             }
             revoked = true;
+            try {
+                registrationStore.updateStatus(email, "Revoked");
+                tryLog(email, "Access revoked", "Owner");
+            } catch (UserRegistrationStore.StoreException exception) {
+                System.getLogger(JdbcUserService.class.getName()).log(
+                        System.Logger.Level.WARNING, "Failed to persist revoke for user.", exception);
+            }
         }
         return revoked;
     }
@@ -285,8 +309,27 @@ public final class JdbcUserService extends UserService {
         if (user != null && !"Owner".equalsIgnoreCase(user.getRole())) {
             user.setStatus("Active");
             restored = true;
+            try {
+                registrationStore.updateStatus(email, "Active");
+                tryLog(email, "Access restored", "Owner");
+            } catch (UserRegistrationStore.StoreException exception) {
+                System.getLogger(JdbcUserService.class.getName()).log(
+                        System.Logger.Level.WARNING, "Failed to persist restore for user.", exception);
+            }
         }
         return restored;
+    }
+
+    private void tryLog(String target, String action, String actor) {
+        try {
+            LogService log = ServiceRegistry.getLogService();
+            if (log != null) {
+                log.addLogEntry(target, action, actor);
+            }
+        } catch (Exception exception) {
+            System.getLogger(JdbcUserService.class.getName()).log(
+                    System.Logger.Level.WARNING, "Failed to log user management action.", exception);
+        }
     }
 
     @Override

--- a/src/main/java/at/jku/se/smarthome/service/real/auth/JdbcUserService.java
+++ b/src/main/java/at/jku/se/smarthome/service/real/auth/JdbcUserService.java
@@ -248,6 +248,7 @@ public final class JdbcUserService extends UserService {
     }
 
     @Override
+    @SuppressWarnings("PMD.OnlyOneReturn")
     public boolean inviteUser(String email, String role) {
         if (email == null || email.isBlank() || !email.contains("@")) {
             return false;
@@ -320,6 +321,7 @@ public final class JdbcUserService extends UserService {
         return restored;
     }
 
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private void tryLog(String target, String action, String actor) {
         try {
             LogService log = ServiceRegistry.getLogService();

--- a/src/main/java/at/jku/se/smarthome/service/real/auth/JdbcUserService.java
+++ b/src/main/java/at/jku/se/smarthome/service/real/auth/JdbcUserService.java
@@ -321,14 +321,14 @@ public final class JdbcUserService extends UserService {
         return restored;
     }
 
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
     private void tryLog(String target, String action, String actor) {
         try {
             LogService log = ServiceRegistry.getLogService();
             if (log != null) {
                 log.addLogEntry(target, action, actor);
             }
-        } catch (Exception exception) {
+        } catch (Throwable exception) {
             System.getLogger(JdbcUserService.class.getName()).log(
                     System.Logger.Level.WARNING, "Failed to log user management action.", exception);
         }

--- a/src/main/java/at/jku/se/smarthome/service/real/auth/UserRegistrationStore.java
+++ b/src/main/java/at/jku/se/smarthome/service/real/auth/UserRegistrationStore.java
@@ -48,6 +48,15 @@ public interface UserRegistrationStore {
     void updateLastLogin(String normalizedEmail) throws StoreException;
 
     /**
+     * Updates the account status of an existing user.
+     *
+     * @param normalizedEmail the email of the user
+     * @param newStatus the new status value
+     * @throws StoreException if database access fails
+     */
+    void updateStatus(String normalizedEmail, String newStatus) throws StoreException;
+
+    /**
      * Persisted user record with authentication and role information.
      *
      * @param email user email address

--- a/src/test/java/at/jku/se/smarthome/service/TestJdbcUserRegistrationStore.java
+++ b/src/test/java/at/jku/se/smarthome/service/TestJdbcUserRegistrationStore.java
@@ -18,7 +18,7 @@ import at.jku.se.smarthome.service.real.auth.UserRegistrationStore;
 /**
  * Unit tests for JdbcUserRegistrationStore.
  */
-@SuppressWarnings("PMD.AtLeastOneConstructor")
+@SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.TooManyMethods"})
 public class TestJdbcUserRegistrationStore {
 
 
@@ -225,10 +225,11 @@ public class TestJdbcUserRegistrationStore {
     }
 
     /**
-     * Test: updateStatus for unknown email does not throw.
+     * Test: updateStatus for unknown email does not throw and leaves store intact.
      */
     @Test
     public void updateStatusUnknownEmailDoesNotThrow() throws Exception {
         store.updateStatus("nobody@example.com", "Revoked");
+        assertFalse(store.emailExists("nobody@example.com"));
     }
 }

--- a/src/test/java/at/jku/se/smarthome/service/TestJdbcUserRegistrationStore.java
+++ b/src/test/java/at/jku/se/smarthome/service/TestJdbcUserRegistrationStore.java
@@ -185,4 +185,50 @@ public class TestJdbcUserRegistrationStore {
             assertTrue(resultSet.getTimestamp(1) != null);
         }
     }
+
+    /**
+     * Test: updateStatus persists new status to database.
+     */
+    @Test
+    public void updateStatusPersistsNewStatus() throws Exception {
+        UserRegistrationStore.PersistedUser user = new UserRegistrationStore.PersistedUser(
+                "member@example.com",
+                "member",
+                "hash",
+                "Member",
+                "Active"
+        );
+        store.save(user);
+
+        store.updateStatus("member@example.com", "Revoked");
+
+        assertEquals("Revoked", store.findByEmail("member@example.com").orElseThrow().status());
+    }
+
+    /**
+     * Test: updateStatus on revoked user can be restored to Active.
+     */
+    @Test
+    public void updateStatusCanRestoreRevokedUser() throws Exception {
+        UserRegistrationStore.PersistedUser user = new UserRegistrationStore.PersistedUser(
+                "member@example.com",
+                "member",
+                "hash",
+                "Member",
+                "Revoked"
+        );
+        store.save(user);
+
+        store.updateStatus("member@example.com", "Active");
+
+        assertEquals("Active", store.findByEmail("member@example.com").orElseThrow().status());
+    }
+
+    /**
+     * Test: updateStatus for unknown email does not throw.
+     */
+    @Test
+    public void updateStatusUnknownEmailDoesNotThrow() throws Exception {
+        store.updateStatus("nobody@example.com", "Revoked");
+    }
 }

--- a/src/test/java/at/jku/se/smarthome/service/TestMockUserServiceInviteRevoke.java
+++ b/src/test/java/at/jku/se/smarthome/service/TestMockUserServiceInviteRevoke.java
@@ -142,6 +142,7 @@ public class TestMockUserServiceInviteRevoke {
     /**
      * Test: revokeUser on the current logged-in user clears the session.
      */
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     @Test
     public void revokeUserCurrentUserClearsSession() {
         StubStore store = new StubStore();
@@ -240,8 +241,6 @@ public class TestMockUserServiceInviteRevoke {
 
         /** Persisted user (optional). */
         private PersistedUser persistedUser;
-        /** Last status update recorded. */
-        private String lastUpdatedStatus;
 
         @Override
         public boolean emailExists(String normalizedEmail) {
@@ -274,7 +273,6 @@ public class TestMockUserServiceInviteRevoke {
 
         @Override
         public void updateStatus(String normalizedEmail, String newStatus) {
-            lastUpdatedStatus = newStatus;
             if (persistedUser != null && persistedUser.email().equals(normalizedEmail)) {
                 persistedUser = new PersistedUser(
                         persistedUser.email(), persistedUser.username(),

--- a/src/test/java/at/jku/se/smarthome/service/TestMockUserServiceInviteRevoke.java
+++ b/src/test/java/at/jku/se/smarthome/service/TestMockUserServiceInviteRevoke.java
@@ -6,11 +6,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mindrot.jbcrypt.BCrypt;
 
 import at.jku.se.smarthome.model.User;
+import at.jku.se.smarthome.service.api.ServiceRegistry;
 import at.jku.se.smarthome.service.api.UserService.LoginStatus;
+import at.jku.se.smarthome.service.mock.MockLogService;
 import at.jku.se.smarthome.service.mock.MockUserService;
 import at.jku.se.smarthome.service.real.auth.UserRegistrationStore;
 
@@ -19,6 +23,23 @@ import at.jku.se.smarthome.service.real.auth.UserRegistrationStore;
  */
 @SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.TooManyMethods"})
 public class TestMockUserServiceInviteRevoke {
+
+    /**
+     * Wires in a MockLogService before each test so tryLog does not hit the real JDBC log service.
+     */
+    @Before
+    public void setUp() {
+        MockLogService.resetForTesting();
+        ServiceRegistry.setLogServiceForTesting(MockLogService.getInstance());
+    }
+
+    /**
+     * Tears down the MockLogService override after each test.
+     */
+    @After
+    public void tearDown() {
+        ServiceRegistry.setLogServiceForTesting(null);
+    }
 
     /**
      * Test: inviteUser with null email returns false.

--- a/src/test/java/at/jku/se/smarthome/service/TestMockUserServiceInviteRevoke.java
+++ b/src/test/java/at/jku/se/smarthome/service/TestMockUserServiceInviteRevoke.java
@@ -1,0 +1,285 @@
+package at.jku.se.smarthome.service;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.mindrot.jbcrypt.BCrypt;
+
+import at.jku.se.smarthome.model.User;
+import at.jku.se.smarthome.service.api.UserService.LoginStatus;
+import at.jku.se.smarthome.service.mock.MockUserService;
+import at.jku.se.smarthome.service.real.auth.UserRegistrationStore;
+
+/**
+ * FR-20 tests for invite, revoke, and restore in {@link MockUserService}.
+ */
+@SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.TooManyMethods"})
+public class TestMockUserServiceInviteRevoke {
+
+    /**
+     * Test: inviteUser with null email returns false.
+     */
+    @Test
+    public void inviteUserNullEmailReturnsFalse() {
+        MockUserService service = new MockUserService(new StubStore());
+        assertFalse(service.inviteUser(null, "Member"));
+    }
+
+    /**
+     * Test: inviteUser with blank email returns false.
+     */
+    @Test
+    public void inviteUserBlankEmailReturnsFalse() {
+        MockUserService service = new MockUserService(new StubStore());
+        assertFalse(service.inviteUser("   ", "Member"));
+    }
+
+    /**
+     * Test: inviteUser with email missing at-sign returns false.
+     */
+    @Test
+    public void inviteUserNoAtSignReturnsFalse() {
+        MockUserService service = new MockUserService(new StubStore());
+        assertFalse(service.inviteUser("notanemail", "Member"));
+    }
+
+    /**
+     * Test: inviteUser with valid new email returns true.
+     */
+    @Test
+    public void inviteUserValidEmailReturnsTrue() {
+        MockUserService service = new MockUserService(new StubStore());
+        assertTrue(service.inviteUser("newmember@example.com", "Member"));
+    }
+
+    /**
+     * Test: inviteUser with valid email adds user with Pending status.
+     */
+    @Test
+    public void inviteUserValidEmailAddsPendingUser() {
+        MockUserService service = new MockUserService(new StubStore());
+        service.inviteUser("newmember@example.com", "Member");
+        User found = service.getUsers().stream()
+                .filter(u -> "newmember@example.com".equals(u.getEmail()))
+                .findFirst()
+                .orElse(null);
+        assertEquals("Pending", found.getStatus());
+    }
+
+    /**
+     * Test: inviteUser with valid email adds user with correct role.
+     */
+    @Test
+    public void inviteUserValidEmailAddsCorrectRole() {
+        MockUserService service = new MockUserService(new StubStore());
+        service.inviteUser("newmember@example.com", "Member");
+        User found = service.getUsers().stream()
+                .filter(u -> "newmember@example.com".equals(u.getEmail()))
+                .findFirst()
+                .orElse(null);
+        assertEquals("Member", found.getRole());
+    }
+
+    /**
+     * Test: inviteUser with duplicate email returns false.
+     */
+    @Test
+    public void inviteUserDuplicateEmailReturnsFalse() {
+        MockUserService service = new MockUserService(new StubStore());
+        service.inviteUser("newmember@example.com", "Member");
+        assertFalse(service.inviteUser("newmember@example.com", "Member"));
+    }
+
+    /**
+     * Test: inviteUser normalizes email to lowercase.
+     */
+    @Test
+    public void inviteUserNormalizesEmailToLowercase() {
+        MockUserService service = new MockUserService(new StubStore());
+        service.inviteUser("New.Member@EXAMPLE.COM", "Member");
+        boolean found = service.getUsers().stream()
+                .anyMatch(u -> "new.member@example.com".equals(u.getEmail()));
+        assertTrue(found);
+    }
+
+    /**
+     * Test: revokeUser on a Member returns true.
+     * Uses the pre-seeded member@smarthome.com that MockUserService adds at construction.
+     */
+    @Test
+    public void revokeUserMemberReturnsTrue() {
+        MockUserService service = new MockUserService(new StubStore());
+        assertTrue(service.revokeUser("member@smarthome.com"));
+    }
+
+    /**
+     * Test: revokeUser on a Member sets status to Revoked.
+     */
+    @Test
+    public void revokeUserMemberSetsStatusRevoked() {
+        MockUserService service = new MockUserService(new StubStore());
+        service.revokeUser("member@smarthome.com");
+        User member = service.getUsers().stream()
+                .filter(u -> "member@smarthome.com".equals(u.getEmail()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("Revoked", member.getStatus());
+    }
+
+    /**
+     * Test: revokeUser on an Owner returns false.
+     */
+    @Test
+    public void revokeUserOwnerReturnsFalse() {
+        MockUserService service = new MockUserService(new StubStore());
+        assertFalse(service.revokeUser("owner@smarthome.com"));
+    }
+
+    /**
+     * Test: revokeUser on the current logged-in user clears the session.
+     */
+    @Test
+    public void revokeUserCurrentUserClearsSession() {
+        StubStore store = new StubStore();
+        store.persistedUser = new UserRegistrationStore.PersistedUser(
+                "member@smarthome.com",
+                "member",
+                BCrypt.hashpw("pass", BCrypt.gensalt()),
+                "Member",
+                "Active"
+        );
+        MockUserService service = new MockUserService(store);
+        service.authenticate("member@smarthome.com", "pass");
+        assertTrue(service.hasActiveSession());
+
+        service.revokeUser("member@smarthome.com");
+
+        assertFalse(service.hasActiveSession());
+    }
+
+    /**
+     * Test: revokeUser on the current logged-in user clears the email.
+     */
+    @Test
+    public void revokeUserCurrentUserClearsEmail() {
+        StubStore store = new StubStore();
+        store.persistedUser = new UserRegistrationStore.PersistedUser(
+                "member@smarthome.com",
+                "member",
+                BCrypt.hashpw("pass", BCrypt.gensalt()),
+                "Member",
+                "Active"
+        );
+        MockUserService service = new MockUserService(store);
+        service.authenticate("member@smarthome.com", "pass");
+        service.revokeUser("member@smarthome.com");
+
+        assertNull(service.getCurrentUserEmail());
+    }
+
+    /**
+     * Test: restoreUser on a revoked Member returns true.
+     */
+    @Test
+    public void restoreUserRevokedMemberReturnsTrue() {
+        MockUserService service = new MockUserService(new StubStore());
+        service.revokeUser("member@smarthome.com");
+        assertTrue(service.restoreUser("member@smarthome.com"));
+    }
+
+    /**
+     * Test: restoreUser on a revoked Member sets status to Active.
+     */
+    @Test
+    public void restoreUserRevokedMemberSetsStatusActive() {
+        MockUserService service = new MockUserService(new StubStore());
+        service.revokeUser("member@smarthome.com");
+        service.restoreUser("member@smarthome.com");
+        User member = service.getUsers().stream()
+                .filter(u -> "member@smarthome.com".equals(u.getEmail()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("Active", member.getStatus());
+    }
+
+    /**
+     * Test: restoreUser on an Owner returns false.
+     */
+    @Test
+    public void restoreUserOwnerReturnsFalse() {
+        MockUserService service = new MockUserService(new StubStore());
+        assertFalse(service.restoreUser("owner@smarthome.com"));
+    }
+
+    /**
+     * Test: a revoked user cannot authenticate.
+     */
+    @Test
+    public void revokedUserCannotAuthenticate() {
+        StubStore store = new StubStore();
+        store.persistedUser = new UserRegistrationStore.PersistedUser(
+                "member@smarthome.com",
+                "member",
+                BCrypt.hashpw("pass", BCrypt.gensalt()),
+                "Member",
+                "Revoked"
+        );
+        MockUserService service = new MockUserService(store);
+        LoginStatus result = service.authenticate("member@smarthome.com", "pass");
+        assertEquals(LoginStatus.ACCOUNT_INACTIVE, result);
+    }
+
+    /**
+     * Minimal stub store used across invite/revoke tests.
+     */
+    private static final class StubStore implements UserRegistrationStore {
+
+        /** Persisted user (optional). */
+        private PersistedUser persistedUser;
+        /** Last status update recorded. */
+        private String lastUpdatedStatus;
+
+        @Override
+        public boolean emailExists(String normalizedEmail) {
+            return persistedUser != null && persistedUser.email().equals(normalizedEmail);
+        }
+
+        @Override
+        public Optional<PersistedUser> findByEmail(String normalizedEmail) {
+            Optional<PersistedUser> result = Optional.empty();
+            if (persistedUser != null && persistedUser.email().equals(normalizedEmail)) {
+                result = Optional.of(persistedUser);
+            }
+            return result;
+        }
+
+        @Override
+        public java.util.List<PersistedUser> findAllUsers() {
+            return persistedUser == null ? java.util.List.of() : java.util.List.of(persistedUser);
+        }
+
+        @Override
+        public void save(PersistedUser user) {
+            this.persistedUser = user;
+        }
+
+        @Override
+        public void updateLastLogin(String normalizedEmail) {
+            // no-op for these tests
+        }
+
+        @Override
+        public void updateStatus(String normalizedEmail, String newStatus) {
+            lastUpdatedStatus = newStatus;
+            if (persistedUser != null && persistedUser.email().equals(normalizedEmail)) {
+                persistedUser = new PersistedUser(
+                        persistedUser.email(), persistedUser.username(),
+                        persistedUser.passwordHash(), persistedUser.role(), newStatus);
+            }
+        }
+    }
+}

--- a/src/test/java/at/jku/se/smarthome/service/TestMockUserServiceLoginLogout.java
+++ b/src/test/java/at/jku/se/smarthome/service/TestMockUserServiceLoginLogout.java
@@ -424,5 +424,15 @@ public class TestMockUserServiceLoginLogout {
         public void updateLastLogin(String normalizedEmail) {
             this.lastLoginUpdatedEmail = normalizedEmail;
         }
+
+        /**
+         * Updates user status.
+         */
+        @Override
+        public void updateStatus(String normalizedEmail, String newStatus) {
+            if (persistedUser != null && persistedUser.email().equals(normalizedEmail)) {
+                persistedUser = new PersistedUser(persistedUser.email(), persistedUser.username(), persistedUser.passwordHash(), persistedUser.role(), newStatus);
+            }
+        }
     }
 }

--- a/src/test/java/at/jku/se/smarthome/service/TestMockUserServiceRegistration.java
+++ b/src/test/java/at/jku/se/smarthome/service/TestMockUserServiceRegistration.java
@@ -275,5 +275,18 @@ public class TestMockUserServiceRegistration {
                 throw new StoreConfigurationException("Missing DB configuration");
             }
         }
+
+        /**
+         * Updates user status.
+         */
+        @Override
+        public void updateStatus(String normalizedEmail, String newStatus) throws StoreException {
+            if (configurationFailure) {
+                throw new StoreConfigurationException("Missing DB configuration");
+            }
+            if (savedUser != null && savedUser.email().equals(normalizedEmail)) {
+                savedUser = new PersistedUser(savedUser.email(), savedUser.username(), savedUser.passwordHash(), savedUser.role(), newStatus);
+            }
+        }
     }
 }


### PR DESCRIPTION
…persistence and logging

- Add updateStatus(email, status) to UserRegistrationStore interface + JdbcUserRegistrationStore
- Wire JdbcUserService.inviteUser to persist invited users (status=Pending, sentinel hash)
- Wire JdbcUserService.revokeUser/restoreUser to call updateStatus for DB persistence
- Add email format validation (null/blank/no-@) to inviteUser in both Mock and Jdbc services
- Normalize invited email to lowercase in MockUserService
- Log invite/revoke/restore actions via LogService in both service implementations
- Add TestMockUserServiceInviteRevoke (17 tests covering happy/sad path for all three ops)
- Add updateStatus tests to TestJdbcUserRegistrationStore
- Update existing stub stores to implement new updateStatus interface method