### PR TITLE
Fix rule engine: stop emitting FAILURE notifications when condition i…

### DIFF
--- a/src/main/java/at/jku/se/smarthome/service/mock/MockRuleService.java
+++ b/src/main/java/at/jku/se/smarthome/service/mock/MockRuleService.java
@@ -215,8 +215,6 @@ public final class MockRuleService implements RuleService {
                 } else {
                     notificationService.addNotification("Rule execution failed: unsupported action in " + rule.getName(), NotificationType.FAILURE);
                 }
-            } else {
-                notificationService.addNotification("Rule execution failed: condition not met for " + rule.getName(), NotificationType.FAILURE);
             }
         } else {
             notificationService.addNotification("Rule execution failed: " + rule.getName() + " is inactive", NotificationType.FAILURE);

--- a/src/main/java/at/jku/se/smarthome/service/real/rule/JdbcRuleService.java
+++ b/src/main/java/at/jku/se/smarthome/service/real/rule/JdbcRuleService.java
@@ -339,10 +339,6 @@ public final class JdbcRuleService implements RuleService {
                         "Rule execution failed: unsupported action in " + rule.getName(),
                         NotificationType.FAILURE);
             }
-        } else {
-            notificationService.addNotification(
-                    "Rule execution failed: condition not met for " + rule.getName(),
-                    NotificationType.FAILURE);
         }
         return executed;
     }

--- a/src/test/java/at/jku/se/smarthome/service/TestMockRuleService.java
+++ b/src/test/java/at/jku/se/smarthome/service/TestMockRuleService.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 
 import java.time.LocalTime;
 
-import at.jku.se.smarthome.model.NotificationEntry;
 import at.jku.se.smarthome.model.NotificationType;
 import at.jku.se.smarthome.model.Rule;
 import at.jku.se.smarthome.service.api.RuleService;
@@ -228,15 +227,16 @@ public class TestMockRuleService {
     }
 
     /**
-     * Test: execute rule emits error notification when condition is not met.
+     * Test: execute rule returns false and emits no notification when condition is not met.
+     * Condition-not-met is normal polling behavior, not an error.
      */
     @Test
-    public void executeRule_conditionNotMet_emitsErrorNotification() {
+    public void executeRule_conditionNotMet_returnsFalseWithNoNotification() {
+        int notificationsBefore = notificationService.getNotifications().size();
         Rule rule = service.addRule("Bed Check", "Device State", "Bed Light", "State = Active", "Turn On", "Main Light");
-        service.executeRule(rule.getId());
-        NotificationEntry note = notificationService.getNotifications().get(0);
-        assertEquals(NotificationType.FAILURE, note.getType());
-        assertTrue(note.getMessage().contains("condition not met"));
+        boolean result = service.executeRule(rule.getId());
+        assertFalse(result);
+        assertEquals(notificationsBefore, notificationService.getNotifications().size());
     }
 
     /**


### PR DESCRIPTION
…s not met

processDueRules() polled all enabled rules every 30 s (and immediately at startup). When a rule's condition was simply not satisfied it called addNotification(... FAILURE), which (a) flooded the notification bell with spurious "Rule execution failed: condition not met" toasts on every launch and (b) blocked the JavaFX thread with a JDBC INSERT per rule per cycle, making the sidebar unresponsive under rapid navigation.

Condition-not-met during background polling is normal — the trigger has not fired yet. The branch is removed; errors are still reported for genuine failures (rule not found, target device missing, unsupported action).

Also updates TestMockRuleService to match the corrected contract.