### PR TITLE
Fix app freeze on startup and rule notification spam

### DIFF
--- a/src/main/java/at/jku/se/smarthome/SmartHomeApp.java
+++ b/src/main/java/at/jku/se/smarthome/SmartHomeApp.java
@@ -9,6 +9,7 @@ import at.jku.se.smarthome.service.api.ServiceRegistry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import javafx.application.Application;
+import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;
@@ -53,23 +54,25 @@ public class SmartHomeApp extends Application {
         primaryStage.setMinWidth(800);
         primaryStage.setMinHeight(600);
         
-        // Load login scene
         loadLoginScene();
-        
-        // Load register scene
         loadRegisterScene();
-        
-        // Load main scene
-        loadMainScene();
 
-        // Start recurring schedule processing after the JavaFX toolkit is fully available.
-        ServiceRegistry.getScheduleService().startRecurringExecution();
-        ServiceRegistry.getRuleService().startRecurringExecution();
-        
-        // Show login scene first
         primaryStage.setScene(loginScene);
         primaryStage.setMaximized(true);
         primaryStage.show();
+
+        // Defer JDBC-backed service init so the login window appears immediately.
+        // loadMainScene() and startRecurringExecution() still run on the JavaFX thread
+        // but only after the login window is visible.
+        Platform.runLater(() -> {
+            try {
+                loadMainScene();
+            } catch (IOException e) {
+                LOGGER.error("Failed to pre-load the main scene.", e);
+            }
+            ServiceRegistry.getScheduleService().startRecurringExecution();
+            ServiceRegistry.getRuleService().startRecurringExecution();
+        });
     }
     
     /**
@@ -142,6 +145,11 @@ public class SmartHomeApp extends Application {
      * Shows the main application scene.
      */
     private void showMainScene() {
+        if (mainScene == null) {
+            // Background init not yet complete — retry on the next event cycle.
+            Platform.runLater(this::showMainScene);
+            return;
+        }
         if (mainController != null) {
             mainController.refreshSessionState();
         }

--- a/src/main/java/at/jku/se/smarthome/service/real/rule/JdbcRuleService.java
+++ b/src/main/java/at/jku/se/smarthome/service/real/rule/JdbcRuleService.java
@@ -10,7 +10,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -59,6 +61,8 @@ public final class JdbcRuleService implements RuleService {
     private final ObservableList<Rule> rules = FXCollections.observableArrayList();
     /** Flag indicating database schema is initialized. */
     private final AtomicBoolean schemaReady = new AtomicBoolean(false);
+    /** Rule IDs whose condition was true on the previous evaluation cycle (edge detection). */
+    private final Set<String> activeRuleIds = new HashSet<>();
 
     /** Scheduler for background rule evaluation. */
     private ScheduledExecutorService ruleScheduler;
@@ -306,9 +310,19 @@ public final class JdbcRuleService implements RuleService {
     }
 
     private void processDueRules() {
+        RoomService roomService = ServiceRegistry.getRoomService();
         for (Rule rule : rules) {
-            if (rule.isEnabled()) {
+            if (!rule.isEnabled()) {
+                activeRuleIds.remove(rule.getId());
+                continue;
+            }
+            Device sourceDevice = roomService.getDeviceByName(rule.getSourceDevice());
+            boolean conditionMet = new RuleEvaluator().evaluate(rule, sourceDevice);
+            if (conditionMet && !activeRuleIds.contains(rule.getId())) {
+                activeRuleIds.add(rule.getId());
                 executeEnabledRule(rule, false);
+            } else if (!conditionMet) {
+                activeRuleIds.remove(rule.getId());
             }
         }
     }

--- a/src/main/java/at/jku/se/smarthome/service/real/rule/JdbcRuleService.java
+++ b/src/main/java/at/jku/se/smarthome/service/real/rule/JdbcRuleService.java
@@ -311,13 +311,14 @@ public final class JdbcRuleService implements RuleService {
 
     private void processDueRules() {
         RoomService roomService = ServiceRegistry.getRoomService();
+        RuleEvaluator evaluator = new RuleEvaluator();
         for (Rule rule : rules) {
             if (!rule.isEnabled()) {
                 activeRuleIds.remove(rule.getId());
                 continue;
             }
             Device sourceDevice = roomService.getDeviceByName(rule.getSourceDevice());
-            boolean conditionMet = new RuleEvaluator().evaluate(rule, sourceDevice);
+            boolean conditionMet = evaluator.evaluate(rule, sourceDevice);
             if (conditionMet && !activeRuleIds.contains(rule.getId())) {
                 activeRuleIds.add(rule.getId());
                 executeEnabledRule(rule, false);


### PR DESCRIPTION
- Defer loadMainScene() and startRecurringExecution() via Platform.runLater so the login window appears immediately instead of blocking on JDBC init
- Add null guard in showMainScene() in case login succeeds before deferred init completes
- Add edge detection to processDueRules(): rules now only fire when their condition transitions false→true, preventing repeated notifications every 30 s while a condition stays permanently true