### PR TITLE
Fix duplicate key error in nextRuleId after rule deletion

### DIFF
--- a/src/main/java/at/jku/se/smarthome/service/mock/MockRuleService.java
+++ b/src/main/java/at/jku/se/smarthome/service/mock/MockRuleService.java
@@ -98,7 +98,7 @@ public final class MockRuleService implements RuleService {
         RuleValidator.Result validation = RuleValidator.validate(triggerType, condition, sourceDevice, roomService);
         if (validation.valid()) {
             rule = new Rule(
-                    "rule-" + String.format("%03d", rules.size() + 1),
+                    nextRuleId(),
                     name,
                     triggerType,
                     sourceDevice,
@@ -390,6 +390,24 @@ public final class MockRuleService implements RuleService {
             }
         }
         return result;
+    }
+
+    private String nextRuleId() {
+        int maxNum = 0;
+        for (Rule rule : rules) {
+            String id = rule.getId();
+            if (id != null && id.startsWith("rule-")) {
+                try {
+                    int num = Integer.parseInt(id.substring(5));
+                    if (num > maxNum) {
+                        maxNum = num;
+                    }
+                } catch (NumberFormatException ignored) {
+                    // skip malformed IDs
+                }
+            }
+        }
+        return String.format("rule-%03d", maxNum + 1);
     }
 
     @Override

--- a/src/main/java/at/jku/se/smarthome/service/mock/MockRuleService.java
+++ b/src/main/java/at/jku/se/smarthome/service/mock/MockRuleService.java
@@ -395,10 +395,10 @@ public final class MockRuleService implements RuleService {
     private String nextRuleId() {
         int maxNum = 0;
         for (Rule rule : rules) {
-            String id = rule.getId();
-            if (id != null && id.startsWith("rule-")) {
+            String ruleId = rule.getId();
+            if (ruleId != null && ruleId.startsWith("rule-")) {
                 try {
-                    int num = Integer.parseInt(id.substring(5));
+                    int num = Integer.parseInt(ruleId.substring(5));
                     if (num > maxNum) {
                         maxNum = num;
                     }

--- a/src/main/java/at/jku/se/smarthome/service/real/rule/JdbcRuleService.java
+++ b/src/main/java/at/jku/se/smarthome/service/real/rule/JdbcRuleService.java
@@ -410,10 +410,10 @@ public final class JdbcRuleService implements RuleService {
     private String nextRuleId() {
         int maxNum = 0;
         for (Rule rule : rules) {
-            String id = rule.getId();
-            if (id != null && id.startsWith("rule-")) {
+            String ruleId = rule.getId();
+            if (ruleId != null && ruleId.startsWith("rule-")) {
                 try {
-                    int num = Integer.parseInt(id.substring(5));
+                    int num = Integer.parseInt(ruleId.substring(5));
                     if (num > maxNum) {
                         maxNum = num;
                     }

--- a/src/main/java/at/jku/se/smarthome/service/real/rule/JdbcRuleService.java
+++ b/src/main/java/at/jku/se/smarthome/service/real/rule/JdbcRuleService.java
@@ -408,9 +408,21 @@ public final class JdbcRuleService implements RuleService {
     }
 
     private String nextRuleId() {
-        // Mirrors MockRuleService format ("rule-001"). Uses size+1 over the cached list,
-        // which is consistent because every add/delete keeps the list in sync with the DB.
-        return String.format("rule-%03d", rules.size() + 1);
+        int maxNum = 0;
+        for (Rule rule : rules) {
+            String id = rule.getId();
+            if (id != null && id.startsWith("rule-")) {
+                try {
+                    int num = Integer.parseInt(id.substring(5));
+                    if (num > maxNum) {
+                        maxNum = num;
+                    }
+                } catch (NumberFormatException ignored) {
+                    // skip malformed IDs
+                }
+            }
+        }
+        return String.format("rule-%03d", maxNum + 1);
     }
 
     // --- conflict helpers (small heuristic, paralleling schedule conflict logic) ---


### PR DESCRIPTION
nextRuleId() used list.size() + 1, which reuses already-existing IDs after a rule is deleted or a conflict-cancel removes a just-created rule. Scan existing IDs for the highest numeric suffix instead.